### PR TITLE
Stereo camera function is integrated.

### DIFF
--- a/src/Camera.h
+++ b/src/Camera.h
@@ -2,6 +2,8 @@
 
 #include "ofMain.h"
 #include "dc1394.h"
+#include <stdlib.h>
+#include <string.h>
 
 // This sets the number of images in the DMA buffer,
 // where libdc stores images until you grab them.
@@ -11,7 +13,7 @@ namespace ofxLibdc {
 
 class Camera {
 public:
-	Camera();
+	Camera(bool isStereoCamera = false);
 	static int getCameraCount();
 	
 	// pre-setup settings
@@ -29,6 +31,10 @@ public:
 	unsigned int getWidth() const;
 	unsigned int getHeight() const;
 	float getFrameRate() const;
+    
+    // stereo camera settings
+    void setStereoCamera(bool isStereo);
+    bool isStereoCamera() const;
 	
 	virtual bool setup(int cameraNumber = 0);
 	virtual bool setup(string cameraGuid);
@@ -105,7 +111,9 @@ public:
 	// image grabbing
 	
 	bool grabStill(ofImage& img);
+    bool grabStill(ofImage& img1, ofImage& img2);
 	bool grabVideo(ofImage& img, bool dropFrames = true);
+    bool grabVideo(ofImage& img1, ofImage& img2, bool dropFrames = true);
 	
 	void flushBuffer();
 	
@@ -117,6 +125,11 @@ protected:
 	static int libdcCameras;
 	static void startLibdcContext();
 	static void stopLibdcContext();
+    
+    bool isStereo;
+    dc1394stereo_method_t stereoMethod;
+    dc1394color_coding_t colorCoding;
+    dc1394bayer_method_t bayerMethod;
 	
 	static ofImageType getOfImageType(dc1394color_coding_t imageType);
 	static dc1394color_coding_t getLibdcType(ofImageType imageType);
@@ -137,6 +150,7 @@ protected:
 	bool ready;
 	
 	bool grabFrame(ofImage& img);
+    bool grabFrame(ofImage& img1, ofImage& img2);
 	bool initCamera(uint64_t cameraGuid);
 	bool applySettings();
 	


### PR DESCRIPTION
I integrated stereo camera support to Camera class without changing any usage. The only method that should be called to switch to stereo camera mode is setStereoCamera method. When the stereo mode is active, all editable parameters such as Format7, Bayer ...etc is adjusted in setup(). Otherwise, the usage of library is exactly the same as the old. Basically, I overrided the grabVideo and grabStill methods to grab stereo frames. 

Unfortunately, I had only the opportunity to test with Bumblebee2 that I only have. It has limited features for stereo capture, because I could not take into account more use cases. Now, it can perfectly de-interlace stereo frames and convert them into RGB images. 

The simplest example in stereo mode looks like:

``` c++
#include "ofxLibdc.h"

class testApp : public ofBaseApp {
public:
    ofxLibdc::Camera camera;
    ofImage frame1;
    ofImage frame2;

    void setup() {
        camera.setStereoCamera(true);
        camera.setup();
    }

    void update() {
        if (camera.grabVideo(frame1, frame2)) {
            frame1.update();
            frame2.update();
        }
    }

    void draw() {
        frame1.draw(0, 0);
        frame2.draw(camera.getWidth(), 0);
    }
};
```
